### PR TITLE
Add noDailyDealPurchaseLimit cheat

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -39,6 +39,7 @@
   "noArgonCrystalDecay": false,
   "noMasteryRankUpCooldown": false,
   "noVendorPurchaseLimits": false,
+  "noDailyDealPurchaseLimit": false,
   "noDeathMarks": false,
   "noKimCooldowns": false,
   "fullyStockedVendors": false,

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -46,6 +46,7 @@ export interface IConfig {
     noArgonCrystalDecay?: boolean;
     noMasteryRankUpCooldown?: boolean;
     noVendorPurchaseLimits?: boolean;
+    noDailyDealPurchaseLimit?: boolean;
     noDeathMarks?: boolean;
     noKimCooldowns?: boolean;
     fullyStockedVendors?: boolean;

--- a/src/services/purchaseService.ts
+++ b/src/services/purchaseService.ts
@@ -347,8 +347,10 @@ export const handleDailyDealPurchase = async (
         updateCurrency(inventory, dailyDeal.SalePrice, true, purchaseResponse.InventoryChanges);
     }
 
-    inventory.UsedDailyDeals.push(purchaseParams.StoreItem);
-    purchaseResponse.DailyDealUsed = purchaseParams.StoreItem;
+    if (!config.noDailyDealPurchaseLimit) {
+        inventory.UsedDailyDeals.push(purchaseParams.StoreItem);
+        purchaseResponse.DailyDealUsed = purchaseParams.StoreItem;
+    }
 };
 
 export const handleBundleAcqusition = async (

--- a/static/webui/index.html
+++ b/static/webui/index.html
@@ -693,6 +693,10 @@
                                         <label class="form-check-label" for="noVendorPurchaseLimits" data-loc="cheats_noVendorPurchaseLimits"></label>
                                     </div>
                                     <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" id="noDailyDealPurchaseLimit" />
+                                        <label class="form-check-label" for="noDailyDealPurchaseLimit" data-loc="cheats_noDailyDealPurchaseLimit"></label>
+                                    </div>
+                                    <div class="form-check">
                                         <input class="form-check-input" type="checkbox" id="noDeathMarks" />
                                         <label class="form-check-label" for="noDeathMarks" data-loc="cheats_noDeathMarks"></label>
                                     </div>

--- a/static/webui/translations/de.js
+++ b/static/webui/translations/de.js
@@ -156,6 +156,7 @@ dict = {
     cheats_noArgonCrystalDecay: `Argon-Kristalle verschwinden niemals`,
     cheats_noMasteryRankUpCooldown: `Keine Wartezeit beim Meisterschaftsrangaufstieg`,
     cheats_noVendorPurchaseLimits: `Keine Kaufbeschränkungen bei Händlern`,
+    cheats_noDailyDealPurchaseLimit: `[UNTRANSLATED] No Daily Deal Purchase Limit`,
     cheats_noDeathMarks: `Keine Todesmarkierungen`,
     cheats_noKimCooldowns: `Keine Wartezeit bei KIM`,
     cheats_fullyStockedVendors: `[UNTRANSLATED] Fully Stocked Vendors`,

--- a/static/webui/translations/en.js
+++ b/static/webui/translations/en.js
@@ -155,6 +155,7 @@ dict = {
     cheats_noArgonCrystalDecay: `No Argon Crystal Decay`,
     cheats_noMasteryRankUpCooldown: `No Mastery Rank Up Cooldown`,
     cheats_noVendorPurchaseLimits: `No Vendor Purchase Limits`,
+    cheats_noDailyDealPurchaseLimit: `No Daily Deal Purchase Limit`,
     cheats_noDeathMarks: `No Death Marks`,
     cheats_noKimCooldowns: `No KIM Cooldowns`,
     cheats_fullyStockedVendors: `Fully Stocked Vendors`,

--- a/static/webui/translations/es.js
+++ b/static/webui/translations/es.js
@@ -156,6 +156,7 @@ dict = {
     cheats_noArgonCrystalDecay: `Sin descomposición de cristal de Argón`,
     cheats_noMasteryRankUpCooldown: `Sin tiempo de espera para rango de maestría`,
     cheats_noVendorPurchaseLimits: `Sin límite de compras de vendedores`,
+    cheats_noDailyDealPurchaseLimit: `[UNTRANSLATED] No Daily Deal Purchase Limit`,
     cheats_noDeathMarks: `Sin marcas de muerte`,
     cheats_noKimCooldowns: `Sin tiempo de espera para conversaciones KIM`,
     cheats_fullyStockedVendors: `[UNTRANSLATED] Fully Stocked Vendors`,

--- a/static/webui/translations/fr.js
+++ b/static/webui/translations/fr.js
@@ -156,6 +156,7 @@ dict = {
     cheats_noArgonCrystalDecay: `Aucune désintégration des Cristaux d'Argon`,
     cheats_noMasteryRankUpCooldown: `Aucune attente pour la montée de rang de maîtrise`,
     cheats_noVendorPurchaseLimits: `Aucune limite d'achat chez les PNJ`,
+    cheats_noDailyDealPurchaseLimit: `[UNTRANSLATED] No Daily Deal Purchase Limit`,
     cheats_noDeathMarks: `Aucune marque d'assassin`,
     cheats_noKimCooldowns: `Aucun cooldown sur le KIM`,
     cheats_fullyStockedVendors: `[UNTRANSLATED] Fully Stocked Vendors`,

--- a/static/webui/translations/ru.js
+++ b/static/webui/translations/ru.js
@@ -156,6 +156,7 @@ dict = {
     cheats_noArgonCrystalDecay: `Без распада аргоновых кристаллов`,
     cheats_noMasteryRankUpCooldown: `Повышение ранга мастерства без кулдауна`,
     cheats_noVendorPurchaseLimits: `Отсутствие лимитов на покупки у вендоров`,
+    cheats_noDailyDealPurchaseLimit: `[UNTRANSLATED] No Daily Deal Purchase Limit`,
     cheats_noDeathMarks: `Без меток сметри`,
     cheats_noKimCooldowns: `Чаты KIM без кулдауна`,
     cheats_fullyStockedVendors: `[UNTRANSLATED] Fully Stocked Vendors`,

--- a/static/webui/translations/zh.js
+++ b/static/webui/translations/zh.js
@@ -156,6 +156,7 @@ dict = {
     cheats_noArgonCrystalDecay: `氩结晶无衰变`,
     cheats_noMasteryRankUpCooldown: `段位考核无冷却时间`,
     cheats_noVendorPurchaseLimits: `商城或商人无购买限制`,
+    cheats_noDailyDealPurchaseLimit: `[UNTRANSLATED] No Daily Deal Purchase Limit`,
     cheats_noDeathMarks: `无死亡标记(不会被 Stalker/Grustrag 三霸/Zanuka 猎人等标记)`,
     cheats_noKimCooldowns: `无 KIM 冷却时间`,
     cheats_fullyStockedVendors: `[UNTRANSLATED] Fully Stocked Vendors`,


### PR DESCRIPTION
## Summary
- add `noDailyDealPurchaseLimit` flag to config
- skip daily deal usage tracking when this cheat is enabled
- expose the cheat via WebUI checkbox and translations

## Testing
- `npm ci`
- `npm run prettier`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_685995ded3d083259c31e177833790e4