### PR TITLE
Add optional bug-fix settings section

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -25,10 +25,6 @@
   "dontSubtractPurchaseStandingCost": false,
   "dontSubtractVoidTraces": false,
   "dontSubtractConsumables": false,
-  "bugFixes": {
-    "ignore1999LastRegionPlayed": false,
-    "fixXtraCheeseTimer": false
-  },
   "unlockAllShipFeatures": false,
   "unlockAllShipDecorations": false,
   "unlockAllFlavourItems": false,
@@ -62,6 +58,10 @@
   "unlockAllSimarisResearchEntries": false,
   "spoofMasteryRank": -1,
   "nightwaveStandingMultiplier": 1,
+  "unfaithfulBugFixes": {
+    "ignore1999LastRegionPlayed": false,
+    "fixXtraCheeseTimer": false
+  },
   "worldState": {
     "creditBoost": false,
     "affinityBoost": false,

--- a/config.json.example
+++ b/config.json.example
@@ -25,6 +25,10 @@
   "dontSubtractPurchaseStandingCost": false,
   "dontSubtractVoidTraces": false,
   "dontSubtractConsumables": false,
+  "bugFixes": {
+    "ignore1999LastRegionPlayed": false,
+    "fixXtraCheeseTimer": false
+  },
   "unlockAllShipFeatures": false,
   "unlockAllShipDecorations": false,
   "unlockAllFlavourItems": false,

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -65,7 +65,7 @@ export interface IConfig {
     unlockAllSimarisResearchEntries?: boolean;
     spoofMasteryRank?: number;
     nightwaveStandingMultiplier?: number;
-    bugFixes?: {
+    unfaithfulBugFixes?: {
         ignore1999LastRegionPlayed?: boolean;
         fixXtraCheeseTimer?: boolean;
     };

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -65,6 +65,10 @@ export interface IConfig {
     unlockAllSimarisResearchEntries?: boolean;
     spoofMasteryRank?: number;
     nightwaveStandingMultiplier?: number;
+    bugFixes?: {
+        ignore1999LastRegionPlayed?: boolean;
+        fixXtraCheeseTimer?: boolean;
+    };
     worldState?: {
         creditBoost?: boolean;
         affinityBoost?: boolean;

--- a/src/services/missionInventoryUpdateService.ts
+++ b/src/services/missionInventoryUpdateService.ts
@@ -259,7 +259,9 @@ export const addMissionInventoryUpdates = async (
                 addMissionComplete(inventory, value);
                 break;
             case "LastRegionPlayed":
-                inventory.LastRegionPlayed = value;
+                if (!(config.bugFixes?.ignore1999LastRegionPlayed && value === "1999MapName")) {
+                    inventory.LastRegionPlayed = value;
+                }
                 break;
             case "RawUpgrades":
                 addMods(inventory, value);

--- a/src/services/missionInventoryUpdateService.ts
+++ b/src/services/missionInventoryUpdateService.ts
@@ -259,7 +259,7 @@ export const addMissionInventoryUpdates = async (
                 addMissionComplete(inventory, value);
                 break;
             case "LastRegionPlayed":
-                if (!(config.bugFixes?.ignore1999LastRegionPlayed && value === "1999MapName")) {
+                if (!(config.unfaithfulBugFixes?.ignore1999LastRegionPlayed && value === "1999MapName")) {
                     inventory.LastRegionPlayed = value;
                 }
                 break;

--- a/src/services/worldStateService.ts
+++ b/src/services/worldStateService.ts
@@ -1333,7 +1333,7 @@ export const getWorldState = (buildLabel?: string): IWorldState => {
     // Live servers only update the start time once it happens, which makes the
     // client show a negative countdown during off-hours. Optionally adjust the
     // times so the next activation is always in the future.
-    if (config.bugFixes?.fixXtraCheeseTimer && timeSecs >= cheeseEnd) {
+    if (config.unfaithfulBugFixes?.fixXtraCheeseTimer && timeSecs >= cheeseEnd) {
         cheeseStart = cheeseNext;
         cheeseEnd = cheeseStart + cheeseDuration;
         cheeseNext += cheeseInterval;

--- a/src/services/worldStateService.ts
+++ b/src/services/worldStateService.ts
@@ -1327,6 +1327,17 @@ export const getWorldState = (buildLabel?: string): IWorldState => {
     const cheeseInterval = hourInSeconds * 8;
     const cheeseDuration = hourInSeconds * 2;
     const cheeseIndex = Math.trunc(timeSecs / cheeseInterval);
+    let cheeseStart = cheeseIndex * cheeseInterval;
+    let cheeseEnd = cheeseStart + cheeseDuration;
+    let cheeseNext = (cheeseIndex + 1) * cheeseInterval;
+    // Live servers only update the start time once it happens, which makes the
+    // client show a negative countdown during off-hours. Optionally adjust the
+    // times so the next activation is always in the future.
+    if (config.bugFixes?.fixXtraCheeseTimer && timeSecs >= cheeseEnd) {
+        cheeseStart = cheeseNext;
+        cheeseEnd = cheeseStart + cheeseDuration;
+        cheeseNext += cheeseInterval;
+    }
     const tmp: ITmp = {
         cavabegin: "1690761600",
         PurchasePlatformLockEnabled: true,
@@ -1351,9 +1362,9 @@ export const getWorldState = (buildLabel?: string): IWorldState => {
         ennnd: true,
         mbrt: true,
         fbst: {
-            a: cheeseIndex * cheeseInterval, // This has a bug where the client shows a negative time for "Xtra cheese starts in ..." until it refreshes the world state. This is because we're only providing the new activation as soon as that time/date is reached. However, this is 100% faithful to live.
-            e: cheeseIndex * cheeseInterval + cheeseDuration,
-            n: (cheeseIndex + 1) * cheeseInterval
+            a: cheeseStart,
+            e: cheeseEnd,
+            n: cheeseNext
         },
         sfn: [550, 553, 554, 555][halfHour % 4]
     };


### PR DESCRIPTION
## Summary
- group the `ignore1999LastRegionPlayed` and `fixXtraCheeseTimer` options under a new `bugFixes` section
- check this subsection in mission inventory updates and world state generation

## Testing
- `npm run prettier`
- `npm run verify` *(fails: tsgo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e8431dc88325a86416813627b3ef