### PR TITLE
feat: add per-account Profit Taker unlock

### DIFF
--- a/config-vanilla.json
+++ b/config-vanilla.json
@@ -19,7 +19,6 @@
   "unlockAllSkins": false,
   "unlockAllCapturaScenes": false,
   "fullyStockedVendors": false,
-  "unlockAllProfitTakerStages": false,
   "skipClanKeyCrafting": false,
   "noDojoRoomBuildStage": false,
   "noDecoBuildStage": false,

--- a/src/controllers/api/inventoryController.ts
+++ b/src/controllers/api/inventoryController.ts
@@ -486,19 +486,6 @@ export const getInventoryResponse = async (
         }
     }
 
-    if (config.unlockAllProfitTakerStages) {
-        inventoryResponse.CompletedJobChains ??= [];
-        const EudicoHeists = inventoryResponse.CompletedJobChains.find(x => x.LocationTag == "EudicoHeists");
-        if (EudicoHeists) {
-            EudicoHeists.Jobs = allEudicoHeistJobs;
-        } else {
-            inventoryResponse.CompletedJobChains.push({
-                LocationTag: "EudicoHeists",
-                Jobs: allEudicoHeistJobs
-            });
-        }
-    }
-
     if (config.unlockAllSimarisResearchEntries) {
         inventoryResponse.LibraryPersonalTarget = undefined;
         inventoryResponse.LibraryPersonalProgress = [
@@ -514,13 +501,6 @@ export const getInventoryResponse = async (
 
     return inventoryResponse;
 };
-
-const allEudicoHeistJobs = [
-    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyOne",
-    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyTwo",
-    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyThree",
-    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyFour"
-];
 
 const getExpRequiredForMr = (rank: number): number => {
     if (rank <= 30) {

--- a/src/controllers/custom/unlockAllProfitTakerStagesController.ts
+++ b/src/controllers/custom/unlockAllProfitTakerStagesController.ts
@@ -1,0 +1,24 @@
+import { getInventory } from "../../services/inventoryService.ts";
+import { getAccountIdForRequest } from "../../services/loginService.ts";
+import type { RequestHandler } from "express";
+
+const allEudicoHeistJobs = [
+    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyOne",
+    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyTwo",
+    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyThree",
+    "/Lotus/Types/Gameplay/Venus/Jobs/Heists/HeistProfitTakerBountyFour"
+];
+
+export const unlockAllProfitTakerStagesController: RequestHandler = async (req, res) => {
+    const accountId = await getAccountIdForRequest(req);
+    const inventory = await getInventory(accountId);
+    inventory.CompletedJobChains ??= [];
+    const chain = inventory.CompletedJobChains.find(x => x.LocationTag == "EudicoHeists");
+    if (chain) {
+        chain.Jobs = allEudicoHeistJobs;
+    } else {
+        inventory.CompletedJobChains.push({ LocationTag: "EudicoHeists", Jobs: allEudicoHeistJobs });
+    }
+    await inventory.save();
+    res.end();
+};

--- a/src/controllers/custom/unlockAllProfitTakerStagesController.ts
+++ b/src/controllers/custom/unlockAllProfitTakerStagesController.ts
@@ -11,7 +11,7 @@ const allEudicoHeistJobs = [
 
 export const unlockAllProfitTakerStagesController: RequestHandler = async (req, res) => {
     const accountId = await getAccountIdForRequest(req);
-    const inventory = await getInventory(accountId);
+    const inventory = await getInventory(accountId, "CompletedJobChains");
     inventory.CompletedJobChains ??= [];
     const chain = inventory.CompletedJobChains.find(x => x.LocationTag == "EudicoHeists");
     if (chain) {

--- a/src/routes/custom.ts
+++ b/src/routes/custom.ts
@@ -14,6 +14,7 @@ import { addMissingMaxRankModsController } from "../controllers/custom/addMissin
 import { webuiFileChangeDetectedController } from "../controllers/custom/webuiFileChangeDetectedController.ts";
 import { completeAllMissionsController } from "../controllers/custom/completeAllMissionsController.ts";
 import { addMissingHelminthBlueprintsController } from "../controllers/custom/addMissingHelminthBlueprintsController.ts";
+import { unlockAllProfitTakerStagesController } from "../controllers/custom/unlockAllProfitTakerStagesController.ts";
 
 import { abilityOverrideController } from "../controllers/custom/abilityOverrideController.ts";
 import { createAccountController } from "../controllers/custom/createAccountController.ts";
@@ -48,6 +49,7 @@ customRouter.get("/addMissingMaxRankMods", addMissingMaxRankModsController);
 customRouter.get("/webuiFileChangeDetected", webuiFileChangeDetectedController);
 customRouter.get("/completeAllMissions", completeAllMissionsController);
 customRouter.get("/addMissingHelminthBlueprints", addMissingHelminthBlueprintsController);
+customRouter.get("/unlockAllProfitTakerStages", unlockAllProfitTakerStagesController);
 
 customRouter.post("/abilityOverride", abilityOverrideController);
 customRouter.post("/createAccount", createAccountController);

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -27,7 +27,6 @@ export interface IConfig extends IConfigRemovedOptions {
     unlockAllCapturaScenes?: boolean;
     unlockAllDecoRecipes?: boolean;
     fullyStockedVendors?: boolean;
-    unlockAllProfitTakerStages?: boolean;
     skipClanKeyCrafting?: boolean;
     noDojoRoomBuildStage?: boolean;
     noDojoDecoBuildStage?: boolean;

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -109,6 +109,7 @@ export const configRemovedOptionsKeys = [
     "unlockDoubleCapacityPotatoesEverywhere",
     "unlockExilusEverywhere",
     "unlockArcanesEverywhere",
+    "unlockAllProfitTakerStages",
     "noDailyStandingLimits",
     "noDailyFocusLimit",
     "noArgonCrystalDecay",

--- a/static/webui/index.html
+++ b/static/webui/index.html
@@ -758,11 +758,11 @@
                                 <div class="mt-2 mb-2 d-flex flex-wrap gap-2">
                                     <button class="btn btn-primary" onclick="debounce(doUnlockAllMissions);" data-loc="cheats_unlockAllMissions"></button>
                                     <button class="btn btn-primary" onclick="debounce(markAllAsRead);" data-loc="cheats_markAllAsRead"></button>
-                                    <button class="btn btn-primary" onclick="debounce(doUnlockAllProfitTakerStages);" data-loc="cheats_unlockAllProfitTakerStages"></button>
                                     <button class="btn btn-primary" onclick="doUnlockAllFocusSchools();" data-loc="cheats_unlockAllFocusSchools"></button>
                                     <button class="btn btn-primary" onclick="doHelminthUnlockAll();" data-loc="cheats_helminthUnlockAll"></button>
                                     <button class="btn btn-primary" onclick="debounce(addMissingHelminthRecipes);" data-loc="cheats_addMissingSubsumedAbilities"></button>
                                     <button class="btn btn-primary" onclick="doIntrinsicsUnlockAll();" data-loc="cheats_intrinsicsUnlockAll"></button>
+                                    <button class="btn btn-primary" onclick="debounce(doUnlockAllProfitTakerStages);" data-loc="cheats_unlockAllProfitTakerStages"></button>
                                     <button class="btn btn-primary" onclick="debounce(doMaxPlexus);" data-loc="inventory_maxPlexus"></button>
                                 </div>
                                 <form class="mt-2" onsubmit="doChangeSupportedSyndicate(); return false;">

--- a/static/webui/index.html
+++ b/static/webui/index.html
@@ -758,6 +758,7 @@
                                 <div class="mt-2 mb-2 d-flex flex-wrap gap-2">
                                     <button class="btn btn-primary" onclick="debounce(doUnlockAllMissions);" data-loc="cheats_unlockAllMissions"></button>
                                     <button class="btn btn-primary" onclick="debounce(markAllAsRead);" data-loc="cheats_markAllAsRead"></button>
+                                    <button class="btn btn-primary" onclick="debounce(doUnlockAllProfitTakerStages);" data-loc="cheats_unlockAllProfitTakerStages"></button>
                                     <button class="btn btn-primary" onclick="doUnlockAllFocusSchools();" data-loc="cheats_unlockAllFocusSchools"></button>
                                     <button class="btn btn-primary" onclick="doHelminthUnlockAll();" data-loc="cheats_helminthUnlockAll"></button>
                                     <button class="btn btn-primary" onclick="debounce(addMissingHelminthRecipes);" data-loc="cheats_addMissingSubsumedAbilities"></button>
@@ -821,10 +822,6 @@
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" id="fullyStockedVendors" />
                                         <label class="form-check-label" for="fullyStockedVendors" data-loc="cheats_fullyStockedVendors"></label>
-                                    </div>
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" id="unlockAllProfitTakerStages" />
-                                        <label class="form-check-label" for="unlockAllProfitTakerStages" data-loc="cheats_unlockAllProfitTakerStages"></label>
                                     </div>
                                     <div class="form-check">
                                         <input class="form-check-input" type="checkbox" id="skipClanKeyCrafting" />

--- a/static/webui/script.js
+++ b/static/webui/script.js
@@ -2719,6 +2719,12 @@ async function doUnlockAllMissions() {
     toast(loc("cheats_unlockAllMissions_ok"));
 }
 
+async function doUnlockAllProfitTakerStages() {
+    await revalidateAuthz();
+    await fetch("/custom/unlockAllProfitTakerStages?" + window.authz);
+    toast(loc("cheats_unlockAllProfitTakerStages_ok"));
+}
+
 const importSamples = {
     maxFocus: {
         FocusUpgrades: [

--- a/static/webui/script.js
+++ b/static/webui/script.js
@@ -2722,7 +2722,7 @@ async function doUnlockAllMissions() {
 async function doUnlockAllProfitTakerStages() {
     await revalidateAuthz();
     await fetch("/custom/unlockAllProfitTakerStages?" + window.authz);
-    toast(loc("cheats_unlockAllProfitTakerStages_ok"));
+    toast(loc("cheats_unlockSucc"));
 }
 
 const importSamples = {

--- a/static/webui/translations/de.js
+++ b/static/webui/translations/de.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Baro hat volles Inventar`,
     cheats_syndicateMissionsRepeatable: `Syndikat-Missionen wiederholbar`,
     cheats_unlockAllProfitTakerStages: `Alle Profiteintreiber-Phasen freischalten`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Riven-Mod Herausforderung sofort abschließen`,
     cheats_instantResourceExtractorDrones: `Sofortige Ressourcen-Extraktor-Drohnen`,
     cheats_noResourceExtractorDronesDamage: `Kein Schaden für Ressourcen-Extraktor-Drohnen`,

--- a/static/webui/translations/de.js
+++ b/static/webui/translations/de.js
@@ -210,6 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Baro hat volles Inventar`,
     cheats_syndicateMissionsRepeatable: `Syndikat-Missionen wiederholbar`,
     cheats_unlockAllProfitTakerStages: `Alle Profiteintreiber-Phasen freischalten`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `Riven-Mod Herausforderung sofort abschließen`,
     cheats_instantResourceExtractorDrones: `Sofortige Ressourcen-Extraktor-Drohnen`,
     cheats_noResourceExtractorDronesDamage: `Kein Schaden für Ressourcen-Extraktor-Drohnen`,

--- a/static/webui/translations/de.js
+++ b/static/webui/translations/de.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Baro hat volles Inventar`,
     cheats_syndicateMissionsRepeatable: `Syndikat-Missionen wiederholbar`,
     cheats_unlockAllProfitTakerStages: `Alle Profiteintreiber-Phasen freischalten`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
+    cheats_unlockSucc: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Riven-Mod Herausforderung sofort abschließen`,
     cheats_instantResourceExtractorDrones: `Sofortige Ressourcen-Extraktor-Drohnen`,
     cheats_noResourceExtractorDronesDamage: `Kein Schaden für Ressourcen-Extraktor-Drohnen`,

--- a/static/webui/translations/en.js
+++ b/static/webui/translations/en.js
@@ -209,7 +209,7 @@ dict = {
     cheats_baroFullyStocked: `Baro Fully Stocked`,
     cheats_syndicateMissionsRepeatable: `Syndicate Missions Repeatable`,
     cheats_unlockAllProfitTakerStages: `Unlock All Profit Taker Stages`,
-    cheats_unlockAllProfitTakerStages_ok: `Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Instant Finish Riven Challenge`,
     cheats_instantResourceExtractorDrones: `Instant Resource Extractor Drones`,
     cheats_noResourceExtractorDronesDamage: `No Resource Extractor Drones Damage`,

--- a/static/webui/translations/en.js
+++ b/static/webui/translations/en.js
@@ -209,6 +209,7 @@ dict = {
     cheats_baroFullyStocked: `Baro Fully Stocked`,
     cheats_syndicateMissionsRepeatable: `Syndicate Missions Repeatable`,
     cheats_unlockAllProfitTakerStages: `Unlock All Profit Taker Stages`,
+    cheats_unlockAllProfitTakerStages_ok: `Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `Instant Finish Riven Challenge`,
     cheats_instantResourceExtractorDrones: `Instant Resource Extractor Drones`,
     cheats_noResourceExtractorDronesDamage: `No Resource Extractor Drones Damage`,

--- a/static/webui/translations/en.js
+++ b/static/webui/translations/en.js
@@ -209,7 +209,7 @@ dict = {
     cheats_baroFullyStocked: `Baro Fully Stocked`,
     cheats_syndicateMissionsRepeatable: `Syndicate Missions Repeatable`,
     cheats_unlockAllProfitTakerStages: `Unlock All Profit Taker Stages`,
-    cheats_unlockAllProfitTakerStages_ok: `Successfully unlocked.`,
+    cheats_unlockSucc: `Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Instant Finish Riven Challenge`,
     cheats_instantResourceExtractorDrones: `Instant Resource Extractor Drones`,
     cheats_noResourceExtractorDronesDamage: `No Resource Extractor Drones Damage`,

--- a/static/webui/translations/es.js
+++ b/static/webui/translations/es.js
@@ -210,6 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Baro con stock completo`,
     cheats_syndicateMissionsRepeatable: `Misiones de sindicato rejugables`,
     cheats_unlockAllProfitTakerStages: `Desbloquea todas las etapas del Roba-ganancias`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `Terminar desafío de agrietado inmediatamente`,
     cheats_instantResourceExtractorDrones: `Drones de extracción de recursos instantáneos`,
     cheats_noResourceExtractorDronesDamage: `Sin daño a los drones extractores de recursos`,

--- a/static/webui/translations/es.js
+++ b/static/webui/translations/es.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Baro con stock completo`,
     cheats_syndicateMissionsRepeatable: `Misiones de sindicato rejugables`,
     cheats_unlockAllProfitTakerStages: `Desbloquea todas las etapas del Roba-ganancias`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Terminar desafío de agrietado inmediatamente`,
     cheats_instantResourceExtractorDrones: `Drones de extracción de recursos instantáneos`,
     cheats_noResourceExtractorDronesDamage: `Sin daño a los drones extractores de recursos`,

--- a/static/webui/translations/es.js
+++ b/static/webui/translations/es.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Baro con stock completo`,
     cheats_syndicateMissionsRepeatable: `Misiones de sindicato rejugables`,
     cheats_unlockAllProfitTakerStages: `Desbloquea todas las etapas del Roba-ganancias`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
+    cheats_unlockSucc: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Terminar desafío de agrietado inmediatamente`,
     cheats_instantResourceExtractorDrones: `Drones de extracción de recursos instantáneos`,
     cheats_noResourceExtractorDronesDamage: `Sin daño a los drones extractores de recursos`,

--- a/static/webui/translations/fr.js
+++ b/static/webui/translations/fr.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Stock de Baro au max`,
     cheats_syndicateMissionsRepeatable: `Mission syndicat répétables`,
     cheats_unlockAllProfitTakerStages: `Débloquer toutes les étapes du Preneur de Profit`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
+    cheats_unlockSucc: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Débloquer le challenge Riven instantanément`,
     cheats_instantResourceExtractorDrones: `Ressources de drones d'extraction instantannées`,
     cheats_noResourceExtractorDronesDamage: `Aucun dégâts aux drones d'extraction de resources`,

--- a/static/webui/translations/fr.js
+++ b/static/webui/translations/fr.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Stock de Baro au max`,
     cheats_syndicateMissionsRepeatable: `Mission syndicat répétables`,
     cheats_unlockAllProfitTakerStages: `Débloquer toutes les étapes du Preneur de Profit`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Débloquer le challenge Riven instantanément`,
     cheats_instantResourceExtractorDrones: `Ressources de drones d'extraction instantannées`,
     cheats_noResourceExtractorDronesDamage: `Aucun dégâts aux drones d'extraction de resources`,

--- a/static/webui/translations/fr.js
+++ b/static/webui/translations/fr.js
@@ -210,6 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Stock de Baro au max`,
     cheats_syndicateMissionsRepeatable: `Mission syndicat répétables`,
     cheats_unlockAllProfitTakerStages: `Débloquer toutes les étapes du Preneur de Profit`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `Débloquer le challenge Riven instantanément`,
     cheats_instantResourceExtractorDrones: `Ressources de drones d'extraction instantannées`,
     cheats_noResourceExtractorDronesDamage: `Aucun dégâts aux drones d'extraction de resources`,

--- a/static/webui/translations/ru.js
+++ b/static/webui/translations/ru.js
@@ -210,6 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Баро полностью укомплектован`,
     cheats_syndicateMissionsRepeatable: `Повторять миссии синдиката`,
     cheats_unlockAllProfitTakerStages: `Разблокировать все этапы Сферы извлечения прибыли`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `Мгновенное завершение испытания мода Разлома`,
     cheats_instantResourceExtractorDrones: `Мгновенно добывающие Дроны-сборщики`,
     cheats_noResourceExtractorDronesDamage: `Без урона по Дронам-сборщикам`,

--- a/static/webui/translations/ru.js
+++ b/static/webui/translations/ru.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Баро полностью укомплектован`,
     cheats_syndicateMissionsRepeatable: `Повторять миссии синдиката`,
     cheats_unlockAllProfitTakerStages: `Разблокировать все этапы Сферы извлечения прибыли`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Мгновенное завершение испытания мода Разлома`,
     cheats_instantResourceExtractorDrones: `Мгновенно добывающие Дроны-сборщики`,
     cheats_noResourceExtractorDronesDamage: `Без урона по Дронам-сборщикам`,

--- a/static/webui/translations/ru.js
+++ b/static/webui/translations/ru.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Баро полностью укомплектован`,
     cheats_syndicateMissionsRepeatable: `Повторять миссии синдиката`,
     cheats_unlockAllProfitTakerStages: `Разблокировать все этапы Сферы извлечения прибыли`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
+    cheats_unlockSucc: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Мгновенное завершение испытания мода Разлома`,
     cheats_instantResourceExtractorDrones: `Мгновенно добывающие Дроны-сборщики`,
     cheats_noResourceExtractorDronesDamage: `Без урона по Дронам-сборщикам`,

--- a/static/webui/translations/uk.js
+++ b/static/webui/translations/uk.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Баро повністю укомплектований`,
     cheats_syndicateMissionsRepeatable: `Повторювати місії синдиката`,
     cheats_unlockAllProfitTakerStages: `Розблокувати всі етапи Привласнювачки`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
+    cheats_unlockSucc: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Миттєве завершення випробування модифікатора Розколу`,
     cheats_instantResourceExtractorDrones: `Миттєво добуваючі Дрони-видобувачі`,
     cheats_noResourceExtractorDronesDamage: `Без шкоди по Дронам-видобувачам`,

--- a/static/webui/translations/uk.js
+++ b/static/webui/translations/uk.js
@@ -210,6 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Баро повністю укомплектований`,
     cheats_syndicateMissionsRepeatable: `Повторювати місії синдиката`,
     cheats_unlockAllProfitTakerStages: `Розблокувати всі етапи Привласнювачки`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `Миттєве завершення випробування модифікатора Розколу`,
     cheats_instantResourceExtractorDrones: `Миттєво добуваючі Дрони-видобувачі`,
     cheats_noResourceExtractorDronesDamage: `Без шкоди по Дронам-видобувачам`,

--- a/static/webui/translations/uk.js
+++ b/static/webui/translations/uk.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `Баро повністю укомплектований`,
     cheats_syndicateMissionsRepeatable: `Повторювати місії синдиката`,
     cheats_unlockAllProfitTakerStages: `Розблокувати всі етапи Привласнювачки`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `Миттєве завершення випробування модифікатора Розколу`,
     cheats_instantResourceExtractorDrones: `Миттєво добуваючі Дрони-видобувачі`,
     cheats_noResourceExtractorDronesDamage: `Без шкоди по Дронам-видобувачам`,

--- a/static/webui/translations/zh.js
+++ b/static/webui/translations/zh.js
@@ -210,6 +210,7 @@ dict = {
     cheats_baroFullyStocked: `虚空商人贩卖所有商品`,
     cheats_syndicateMissionsRepeatable: `集团任务可重复完成`,
     cheats_unlockAllProfitTakerStages: `解锁利润收割者圆蛛所有阶段`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
     cheats_instantFinishRivenChallenge: `立即完成裂罅挑战`,
     cheats_instantResourceExtractorDrones: `资源无人机即时完成`,
     cheats_noResourceExtractorDronesDamage: `资源无人机不会损毁`,

--- a/static/webui/translations/zh.js
+++ b/static/webui/translations/zh.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `虚空商人贩卖所有商品`,
     cheats_syndicateMissionsRepeatable: `集团任务可重复完成`,
     cheats_unlockAllProfitTakerStages: `解锁利润收割者圆蛛所有阶段`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
+    cheats_unlockSucc: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `立即完成裂罅挑战`,
     cheats_instantResourceExtractorDrones: `资源无人机即时完成`,
     cheats_noResourceExtractorDronesDamage: `资源无人机不会损毁`,

--- a/static/webui/translations/zh.js
+++ b/static/webui/translations/zh.js
@@ -210,7 +210,7 @@ dict = {
     cheats_baroFullyStocked: `虚空商人贩卖所有商品`,
     cheats_syndicateMissionsRepeatable: `集团任务可重复完成`,
     cheats_unlockAllProfitTakerStages: `解锁利润收割者圆蛛所有阶段`,
-    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked all Profit Taker stages`,
+    cheats_unlockAllProfitTakerStages_ok: `[UNTRANSLATED] Successfully unlocked.`,
     cheats_instantFinishRivenChallenge: `立即完成裂罅挑战`,
     cheats_instantResourceExtractorDrones: `资源无人机即时完成`,
     cheats_noResourceExtractorDronesDamage: `资源无人机不会损毁`,


### PR DESCRIPTION
## Summary
- replace server-wide Profit Taker spoof with per-account unlock
- add web UI button and endpoint to unlock Profit Taker stages
- remove obsolete config option

## Testing
- `npm run update-translations`
- `npm run prettier`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_68afcbe7c6c08325b4cd44241aa4f0f6