### PR TITLE
refactor: replace deprecated substr usage

### DIFF
--- a/src/controllers/api/focusController.ts
+++ b/src/controllers/api/focusController.ts
@@ -231,7 +231,7 @@ interface ILensInstallRequest {
 
 // Works for ways & upgrades
 const focusTypeToPolarity = (type: string): TFocusPolarity => {
-    return ("AP_" + type.substr(1).split("/")[3].toUpperCase()) as TFocusPolarity;
+    return ("AP_" + type.substring(1).split("/")[3].toUpperCase()) as TFocusPolarity;
 };
 
 const shardValues = {

--- a/src/controllers/custom/getItemListsController.ts
+++ b/src/controllers/custom/getItemListsController.ts
@@ -70,7 +70,7 @@ const relicQualitySuffixes: Record<TRelicQuality, string> = {
 };
 
 /*const toTitleCase = (str: string): string => {
-    return str.replace(/[^\s-]+/g, word => word.charAt(0).toUpperCase() + word.substr(1).toLowerCase());
+    return str.replace(/[^\s-]+/g, word => word.charAt(0).toUpperCase() + word.substring(1).toLowerCase());
 };*/
 
 const getItemListsController: RequestHandler = (req, response) => {
@@ -221,7 +221,7 @@ const getItemListsController: RequestHandler = (req, response) => {
         }
         if (
             name &&
-            uniqueName.substr(0, 30) != "/Lotus/Types/Game/Projections/" &&
+            uniqueName.substring(0, 30) != "/Lotus/Types/Game/Projections/" &&
             uniqueName != "/Lotus/Types/Gameplay/EntratiLab/Resources/EntratiLanthornBundle"
         ) {
             res.miscitems.push({

--- a/src/routes/cache.ts
+++ b/src/routes/cache.ts
@@ -14,8 +14,8 @@ cacheRouter.get(/^\/origin\/[a-zA-Z0-9]+\/[0-9]+\/H\.Cache\.bin.*$/, (req, res) 
 
 cacheRouter.get(/^\/0\/.+!.+$/, async (req, res) => {
     try {
-        const dir = req.path.substr(0, req.path.lastIndexOf("/"));
-        const file = req.path.substr(dir.length + 1);
+        const dir = req.path.substring(0, req.path.lastIndexOf("/"));
+        const file = req.path.substring(dir.length + 1);
         const filePath = `static/data${dir}/${file}`;
 
         // Return file if we have it

--- a/src/services/inventoryService.ts
+++ b/src/services/inventoryService.ts
@@ -687,10 +687,10 @@ export const addItem = async (
     }
 
     // Path-based duck typing
-    switch (typeName.substr(1).split("/")[1]) {
+    switch (typeName.substring(1).split("/")[1]) {
         case "Powersuits":
             if (typeName.endsWith("AugmentCard")) break;
-            switch (typeName.substr(1).split("/")[2]) {
+            switch (typeName.substring(1).split("/")[2]) {
                 default: {
                     return {
                         ...(await addPowerSuit(inventory, typeName, {
@@ -725,7 +725,7 @@ export const addItem = async (
             }
             break;
         case "Upgrades": {
-            switch (typeName.substr(1).split("/")[2]) {
+            switch (typeName.substring(1).split("/")[2]) {
                 case "Mods": // Legendary Core
                 case "CosmeticEnhancers": // Traumatic Peculiar
                     {
@@ -782,12 +782,12 @@ export const addItem = async (
             break;
         }
         case "Types":
-            switch (typeName.substr(1).split("/")[2]) {
+            switch (typeName.substring(1).split("/")[2]) {
                 case "Sentinels": {
                     return addSentinel(inventory, typeName, premiumPurchase);
                 }
                 case "Game": {
-                    if (typeName.substr(1).split("/")[3] == "Projections") {
+                    if (typeName.substring(1).split("/")[3] == "Projections") {
                         // Void Relics, e.g. /Lotus/Types/Game/Projections/T2VoidProjectionGaussPrimeDBronze
                         const miscItemChanges = [
                             {
@@ -801,8 +801,8 @@ export const addItem = async (
                             MiscItems: miscItemChanges
                         };
                     } else if (
-                        typeName.substr(1).split("/")[3] == "CatbrowPet" ||
-                        typeName.substr(1).split("/")[3] == "KubrowPet"
+                        typeName.substring(1).split("/")[3] == "CatbrowPet" ||
+                        typeName.substring(1).split("/")[3] == "KubrowPet"
                     ) {
                         if (
                             typeName != "/Lotus/Types/Game/KubrowPet/Eggs/KubrowPetEggItem" &&
@@ -826,7 +826,7 @@ export const addItem = async (
                     break;
                 }
                 case "Items": {
-                    if (typeName.substr(1).split("/")[3] == "Emotes") {
+                    if (typeName.substring(1).split("/")[3] == "Emotes") {
                         return addCustomization(inventory, typeName);
                     }
                     break;
@@ -875,8 +875,8 @@ export const addItem = async (
             }
             break;
         case "Weapons": {
-            if (typeName.substr(1).split("/")[4] == "MeleeTrees") break;
-            const productCategory = typeName.substr(1).split("/")[3];
+            if (typeName.substring(1).split("/")[4] == "MeleeTrees") break;
+            const productCategory = typeName.substring(1).split("/")[3];
             switch (productCategory) {
                 case "Pistols":
                 case "LongGuns":


### PR DESCRIPTION
## Summary
- replace `substr` with `substring` to satisfy `@typescript-eslint/no-deprecated`
- switch cache route path parsing to `substring`
- update inventory service item type parsing to use `substring`

## Testing
- `npm run lint`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_68be6ed9b5648325b42a87be88655d61