### PR TITLE
Validate config.json with Zod and add zod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "warframe-riven-info": "^0.1.2",
         "winston": "^3.17.0",
         "winston-daily-rotate-file": "^5.0.0",
-        "ws": "^8.18.2"
+        "ws": "^8.18.2",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.28.0",
@@ -531,7 +532,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -866,7 +866,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1423,7 +1422,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1982,6 +1980,7 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -1996,6 +1995,7 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -2009,6 +2009,7 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -2025,6 +2026,7 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -2039,6 +2041,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2059,14 +2062,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -2074,6 +2079,7 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3151,7 +3157,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3175,7 +3180,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3891,7 +3895,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4011,7 +4014,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -4203,6 +4205,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "warframe-riven-info": "^0.1.2",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "ws": "^8.18.2"
+    "ws": "^8.18.2",
+    "zod": "^3.25.76"
   },
   "optionalDependencies": {
     "@types/body-parser": "^1.19.6",

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -5,124 +5,139 @@ import { args } from "../helpers/commandLineArguments.ts";
 import { Inbox } from "../models/inboxModel.ts";
 import type { Request } from "express";
 import { Account } from "../models/loginModel.ts";
-import type { TRegionId } from "./arbiterService.ts";
+import { z } from "zod";
 
-export interface IHubServer {
-    address: string;
-    regions?: TRegionId[];
-    dtlsUnsupported?: boolean;
-}
+const regionIdSchema = z.enum(["ASIA", "OCEANIA", "EUROPE", "RUSSIA", "NORTH_AMERICA", "SOUTH_AMERICA"]);
 
-export interface IConfig {
-    mongodbUrl: string;
-    logger: {
-        files: boolean;
-        level: string; // "fatal" | "error" | "warn" | "info" | "http" | "debug" | "trace";
-    };
-    myAddress: string;
-    bindAddress?: string;
-    httpPort?: number;
-    httpsPort?: number;
-    httpsCertFile?: string;
-    httpsKeyFile?: string;
-    ircExecutable?: string;
-    ircAddress?: string;
-    hubExecutable?: string;
-    /** @deprecated */ hubAddress?: string;
-    hubServers?: IHubServer[];
-    noHubDiscrimination?: boolean;
-    /** @deprecated */ nrsAddress?: string;
-    nrsAddresses?: string[];
-    dtls?: number;
-    administratorNames?: string[];
-    autoCreateAccount?: boolean;
-    skipTutorial?: boolean;
-    fullyStockedVendors?: boolean;
-    skipClanKeyCrafting?: boolean;
-    webui?: {
-        enabled?: boolean;
-        defaultLanguage?: string;
-    };
-    unfaithfulBugFixes?: {
-        ignore1999LastRegionPlayed?: boolean;
-        fixXtraCheeseTimer?: boolean;
-        useAnniversaryTagForOldGoals?: boolean;
-    };
-    worldState?: {
-        creditBoost?: boolean;
-        affinityBoost?: boolean;
-        resourceBoost?: boolean;
-        tennoLiveRelay?: boolean;
-        baroTennoConRelay?: boolean;
-        baroAlwaysAvailable?: boolean;
-        baroFullyStocked?: boolean;
-        baroRelayOverride?: number;
-        evilBaroStage?: number;
-        varziaFullyStocked?: boolean;
-        vanguardVaultRelics?: boolean;
-        wolfHunt?: number;
-        scarletSpear?: boolean;
-        orphixVenom?: boolean;
-        bloodOfPerita?: boolean;
-        longShadow?: boolean;
-        hallowedFlame?: boolean;
-        anniversary?: number;
-        hallowedNightmares?: boolean;
-        hallowedNightmaresRewardsOverride?: number;
-        naberusNightsOverride?: boolean;
-        proxyRebellion?: boolean;
-        proxyRebellionRewardsOverride?: number;
-        voidCorruption2025Week1?: boolean;
-        voidCorruption2025Week2?: boolean;
-        voidCorruption2025Week3?: boolean;
-        voidCorruption2025Week4?: boolean;
-        dagathAlerts2026Week1?: boolean;
-        dagathAlerts2026Week2?: boolean;
-        dagathAlerts2026Week3?: boolean;
-        dagathAlerts2026Week4?: boolean;
-        starDaysAlerts2026Week1?: boolean;
-        starDaysAlerts2026Week2?: boolean;
-        starDaysAlerts2026Week3?: boolean;
-        starDaysAlerts2026Week4?: boolean;
-        qtccAlerts?: boolean;
-        galleonOfGhouls?: number;
-        ghoulEmergenceOverride?: boolean;
-        plagueStarOverride?: boolean;
-        starDaysOverride?: boolean;
-        saintPatrickOverride?: boolean;
-        dogDaysOverride?: boolean;
-        dogDaysRewardsOverride?: number;
-        bellyOfTheBeast?: boolean;
-        bellyOfTheBeastProgressOverride?: number;
-        eightClaw?: boolean;
-        eightClawProgressOverride?: number;
-        thermiaFracturesOverride?: boolean;
-        thermiaFracturesProgressOverride?: number;
-        eidolonOverride?: string;
-        vallisOverride?: string;
-        duviriOverride?: string;
-        nightwaveOverride?: string;
-        nightwaveEpisode?: number;
-        allTheFissures?: string;
-        varziaOverride?: string;
-        circuitGameModes?: string[];
-        darvoStockMultiplier?: number;
-    };
-    tunables?: {
-        useLoginToken?: boolean;
-        prohibitSkipMissionStartTimer?: boolean;
-        prohibitDisableProfanityFilter?: boolean;
-        prohibitFovOverride?: boolean;
-        prohibitFreecam?: boolean;
-        prohibitTeleport?: boolean;
-        prohibitScripts?: boolean;
-        motd?: string;
-        udpProxyUpstream?: string;
-    };
-    dev?: {
-        keepVendorsExpired?: boolean;
-    };
-}
+const hubServerSchema = z.object({
+    address: z.string(),
+    regions: z.array(regionIdSchema).optional(),
+    dtlsUnsupported: z.boolean().optional()
+});
+
+const worldStateSchema = z.object({
+    creditBoost: z.boolean().optional(),
+    affinityBoost: z.boolean().optional(),
+    resourceBoost: z.boolean().optional(),
+    tennoLiveRelay: z.boolean().optional(),
+    baroTennoConRelay: z.boolean().optional(),
+    baroAlwaysAvailable: z.boolean().optional(),
+    baroFullyStocked: z.boolean().optional(),
+    baroRelayOverride: z.number().optional(),
+    evilBaroStage: z.number().optional(),
+    varziaFullyStocked: z.boolean().optional(),
+    vanguardVaultRelics: z.boolean().optional(),
+    wolfHunt: z.number().optional(),
+    scarletSpear: z.boolean().optional(),
+    orphixVenom: z.boolean().optional(),
+    bloodOfPerita: z.boolean().optional(),
+    longShadow: z.boolean().optional(),
+    hallowedFlame: z.boolean().optional(),
+    anniversary: z.number().optional(),
+    hallowedNightmares: z.boolean().optional(),
+    hallowedNightmaresRewardsOverride: z.number().optional(),
+    naberusNightsOverride: z.boolean().optional(),
+    proxyRebellion: z.boolean().optional(),
+    proxyRebellionRewardsOverride: z.number().optional(),
+    voidCorruption2025Week1: z.boolean().optional(),
+    voidCorruption2025Week2: z.boolean().optional(),
+    voidCorruption2025Week3: z.boolean().optional(),
+    voidCorruption2025Week4: z.boolean().optional(),
+    dagathAlerts2026Week1: z.boolean().optional(),
+    dagathAlerts2026Week2: z.boolean().optional(),
+    dagathAlerts2026Week3: z.boolean().optional(),
+    dagathAlerts2026Week4: z.boolean().optional(),
+    starDaysAlerts2026Week1: z.boolean().optional(),
+    starDaysAlerts2026Week2: z.boolean().optional(),
+    starDaysAlerts2026Week3: z.boolean().optional(),
+    starDaysAlerts2026Week4: z.boolean().optional(),
+    qtccAlerts: z.boolean().optional(),
+    galleonOfGhouls: z.number().optional(),
+    ghoulEmergenceOverride: z.boolean().optional(),
+    plagueStarOverride: z.boolean().optional(),
+    starDaysOverride: z.boolean().optional(),
+    saintPatrickOverride: z.boolean().optional(),
+    dogDaysOverride: z.boolean().optional(),
+    dogDaysRewardsOverride: z.number().optional(),
+    bellyOfTheBeast: z.boolean().optional(),
+    bellyOfTheBeastProgressOverride: z.number().optional(),
+    eightClaw: z.boolean().optional(),
+    eightClawProgressOverride: z.number().optional(),
+    thermiaFracturesOverride: z.boolean().optional(),
+    thermiaFracturesProgressOverride: z.number().optional(),
+    eidolonOverride: z.string().optional(),
+    vallisOverride: z.string().optional(),
+    duviriOverride: z.string().optional(),
+    nightwaveOverride: z.string().optional(),
+    nightwaveEpisode: z.number().optional(),
+    allTheFissures: z.string().optional(),
+    varziaOverride: z.string().optional(),
+    circuitGameModes: z.array(z.string()).optional(),
+    darvoStockMultiplier: z.number().optional()
+});
+
+const configSchema = z.object({
+    mongodbUrl: z.string(),
+    logger: z.object({
+        files: z.boolean(),
+        level: z.string()
+    }),
+    myAddress: z.string(),
+    bindAddress: z.string().optional(),
+    httpPort: z.number().optional(),
+    httpsPort: z.number().optional(),
+    httpsCertFile: z.string().optional(),
+    httpsKeyFile: z.string().optional(),
+    ircExecutable: z.string().optional(),
+    ircAddress: z.string().optional(),
+    hubExecutable: z.string().optional(),
+    hubAddress: z.string().optional(),
+    hubServers: z.array(hubServerSchema).optional(),
+    noHubDiscrimination: z.boolean().optional(),
+    nrsAddress: z.string().optional(),
+    nrsAddresses: z.array(z.string()).optional(),
+    dtls: z.number().optional(),
+    administratorNames: z.array(z.string()).optional(),
+    autoCreateAccount: z.boolean().optional(),
+    skipTutorial: z.boolean().optional(),
+    fullyStockedVendors: z.boolean().optional(),
+    skipClanKeyCrafting: z.boolean().optional(),
+    webui: z
+        .object({
+            enabled: z.boolean().optional(),
+            defaultLanguage: z.string().optional()
+        })
+        .optional(),
+    unfaithfulBugFixes: z
+        .object({
+            ignore1999LastRegionPlayed: z.boolean().optional(),
+            fixXtraCheeseTimer: z.boolean().optional(),
+            useAnniversaryTagForOldGoals: z.boolean().optional()
+        })
+        .optional(),
+    worldState: worldStateSchema.optional(),
+    tunables: z
+        .object({
+            useLoginToken: z.boolean().optional(),
+            prohibitSkipMissionStartTimer: z.boolean().optional(),
+            prohibitDisableProfanityFilter: z.boolean().optional(),
+            prohibitFovOverride: z.boolean().optional(),
+            prohibitFreecam: z.boolean().optional(),
+            prohibitTeleport: z.boolean().optional(),
+            prohibitScripts: z.boolean().optional(),
+            motd: z.string().optional(),
+            udpProxyUpstream: z.string().optional()
+        })
+        .optional(),
+    dev: z
+        .object({
+            keepVendorsExpired: z.boolean().optional()
+        })
+        .optional()
+});
+
+export type IHubServer = z.infer<typeof hubServerSchema>;
+export type IConfig = z.infer<typeof configSchema>;
 
 export const configRemovedOptionsKeys = [
     "unlockallShipFeatures",
@@ -215,7 +230,17 @@ export const config: IConfig = {
 };
 
 export const loadConfig = (): void => {
-    const newConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")) as IConfig;
+    const rawConfig: unknown = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    const parsedConfig = configSchema.safeParse(rawConfig);
+
+    if (!parsedConfig.success) {
+        const validationErrors = parsedConfig.error.errors
+            .map(error => `${error.path.join(".") || "<root>"}: ${error.message}`)
+            .join("; ");
+        throw new Error(`Invalid config schema: ${validationErrors}`);
+    }
+
+    const newConfig = parsedConfig.data;
 
     // Set all values to undefined now so if the new config.json omits some fields that were previously present, it's correct in-memory.
     for (const key of Object.keys(config)) {


### PR DESCRIPTION
### Motivation

- Add runtime validation for the server `config.json` to catch malformed or missing configuration early and provide clearer error messages.
- Replace the ad-hoc TypeScript interface-only approach with a schema-driven validation to ensure stability when loading config values at startup.

### Description

- Added `zod` to `package.json` and `package-lock.json` and vendored the `node_modules/zod` entry in the lockfile.
- Rewrote `src/services/configService.ts` to define `regionIdSchema`, `hubServerSchema`, `worldStateSchema`, and `configSchema` using `zod` and exported `IHubServer` and `IConfig` via `z.infer` from those schemas.
- Changed `loadConfig` to parse the raw JSON as `unknown`, validate with `configSchema.safeParse`, throw a helpful `Error` with consolidated validation messages when invalid, and assign the validated data into the runtime `config` object.
- Kept the previous behavior of clearing existing keys on `config` before assigning new values so omitted fields are set to `undefined`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b4092810832586c0aeeb49b2a819)